### PR TITLE
Force the GDK backend to x11

### DIFF
--- a/green-recorder
+++ b/green-recorder
@@ -20,12 +20,26 @@ gi.require_version('Gtk','3.0')
 
 from gi.repository import Gtk, Gdk, GLib, AppIndicator3 as appindicator
 from pydbus import SessionBus
-import subprocess, signal, threading, datetime, urllib, gettext, locale, os, ConfigParser, sys
+import subprocess, signal, threading, datetime, gettext, locale, os, sys
+
+try:
+    # Python 3
+    from configparser import ConfigParser
+except ImportError:
+    # Python 2
+    from ConfigParser import SafeConfigParser as ConfigParser
+
+try:
+    # Python 3
+    from urllib.parse import unquote
+except ImportError:
+    # Python 2
+    from urllib import unquote
 
 # Configuration
-confDir =  os.path.join(GLib.get_user_config_dir(), 'green-recorder/')
+confDir = os.path.join(GLib.get_user_config_dir(), 'green-recorder/')
 confFile = os.path.join(confDir + "config.ini")
-config = ConfigParser.ConfigParser()
+config = ConfigParser()
 
 if not os.path.exists(confDir):
   os.makedirs(confDir)
@@ -71,7 +85,7 @@ except:
   DisplayServer = "xorg"
   pass #Ok, cause it means user is using Xorg.
   
-print "You are recording on: " + str(DisplayServer)
+print("You are recording on: " + str(DisplayServer))
 
 if "wayland" in DisplayServer:
   DisplayServer = "gnomewayland"
@@ -103,7 +117,7 @@ def recorderindicator():
     indicator.set_status(appindicator.IndicatorStatus.ACTIVE)
     
     menu = Gtk.Menu()
-    stoprecordingbutton = Gtk.MenuItem(_('Stop Recording'))
+    stoprecordingbutton = Gtk.MenuItem(label=_('Stop Recording'))
     stoprecordingbutton.connect('activate', stoprecording)
     menu.append(stoprecordingbutton)
     menu.show_all()
@@ -267,7 +281,7 @@ def checkbool(s):
 
 def record():
     global RecorderFullPathName # grab the path
-    RecorderFullPathName = urllib.unquote(folderchooser.get_uri() + '/' + filename.get_text() + '.' + formatchooser.get_active_id())
+    RecorderFullPathName = unquote(folderchooser.get_uri() + '/' + filename.get_text() + '.' + formatchooser.get_active_id())
 
     abs_path=RecorderFullPathName.replace("file://",'')
     if os.path.exists(abs_path) and filename.get_text() is not "":
@@ -301,9 +315,9 @@ def record():
     RecorderFrames = str(frames.get_value_as_int())
     
     if len(filename.get_text()) < 1:
-      RecorderFullPathName = urllib.unquote(folderchooser.get_uri() + '/' + str(datetime.datetime.now()) + '.' + formatchooser.get_active_id())
+      RecorderFullPathName = unquote(folderchooser.get_uri() + '/' + str(datetime.datetime.now()) + '.' + formatchooser.get_active_id())
     else:
-      RecorderFullPathName = urllib.unquote(folderchooser.get_uri() + '/' + filename.get_text() + '.' + formatchooser.get_active_id())
+      RecorderFullPathName = unquote(folderchooser.get_uri() + '/' + filename.get_text() + '.' + formatchooser.get_active_id())
       
     RecorderAbsPathName = RecorderFullPathName.replace("file://", "")
     
@@ -436,13 +450,13 @@ try:
   audiosourcesids = subprocess.check_output("pacmd list-sources | grep -e device.string", shell=True)
 except Exception as e:
   print(e)
-audiosourcesnames = audiosourcesnames.split("\n")[:-1]
+audiosourcesnames = audiosourcesnames.split(b"\n")[:-1]
 
 for i in range(len(audiosourcesnames)):
-  audiosourcesnames[i] = audiosourcesnames[i].replace("\t\tdevice.description = ", "")
-  audiosourcesnames[i] = audiosourcesnames[i].replace('"', "")
+  audiosourcesnames[i] = audiosourcesnames[i].replace(b"\t\tdevice.description = ", b"")
+  audiosourcesnames[i] = audiosourcesnames[i].replace(b'"', b"")
   
-  audiosource.append(str(i), audiosourcesnames[i])
+  audiosource.append(str(i), audiosourcesnames[i].decode('UTF-8', 'replace'))
   
 audiosource.set_active(0)
 
@@ -456,7 +470,7 @@ if "wayland" in DisplayServer:
   formatchooser.set_active(0)
 
   try:
-    s = subprocess.check_output("echo $GDK_BACKEND", shell=True)
+    s = os.getenv('GDK_BACKEND', '')
     if "x11" not in s:
       sendnotification(_("You didn't run the program using the application icon (desktop file). This will cause the program not to work. Run it using the icon from the menus only. (Need to export GDK_BACKEND=x11 first)"), 6)
   except Exception as e:
@@ -488,7 +502,7 @@ class Handler:
         stoprecording(_)
         
     def playbuttonclicked(self, GtkButton):
-        subprocess.call(["xdg-open", urllib.unquote(RecorderAbsPathName)])
+        subprocess.call(["xdg-open", unquote(RecorderAbsPathName)])
 
     def areasettings(self, GtkButton):
         output = subprocess.check_output(["xwininfo -name \"Area Chooser\" | grep -e Width -e Height -e Absolute"], shell=True)[:-1]
@@ -518,13 +532,13 @@ class Handler:
           config.write(newconfFile)
           
     def filenamechanged(self, GtkEntry):
-        config.set('Options', 'filename', urllib.unquote(filename.get_text()))
+        config.set('Options', 'filename', unquote(filename.get_text()))
         global confFile
         with open(confFile, 'w+') as newconfFile:
           config.write(newconfFile)
                
     def folderchosen(self, GtkFileChooserButton):
-        config.set('Options', 'folder', urllib.unquote(folderchooser.get_uri()))
+        config.set('Options', 'folder', unquote(folderchooser.get_uri()))
         global confFile
         with open(confFile, 'w+') as newconfFile:
           config.write(newconfFile)
@@ -565,7 +579,7 @@ builder.connect_signals(Handler())
 
 # Load CSS for Area Chooser.
 style_provider = Gtk.CssProvider()
-css = """
+css = b"""
 #AreaChooser {
     background-color: rgba(255, 255, 255, 0);
     border: 1px solid red;

--- a/green-recorder
+++ b/green-recorder
@@ -484,7 +484,7 @@ class Handler:
         output = subprocess.check_output(["xwininfo | grep -e Width -e Height -e Absolute"], shell=True)[:-1]
         
         global areaaxis
-        areaaxis = [int(l.split(':')[1]) for l in output.split('\n')]
+        areaaxis = [int(l.split(':')[1]) for l in output.decode('UTF-8', 'ignore').split('\n')]
         
         global WindowXAxis, WindowYAxis, WindowWidth, WindowHeight
         WindowXAxis = areaaxis[0]
@@ -508,7 +508,7 @@ class Handler:
         output = subprocess.check_output(["xwininfo -name \"Area Chooser\" | grep -e Width -e Height -e Absolute"], shell=True)[:-1]
         
         global areaaxis
-        areaaxis = [int(l.split(':')[1]) for l in output.split('\n')]
+        areaaxis = [int(l.split(':')[1]) for l in output.decode('UTF-8', 'ignore').split('\n')]
         
         global WindowXAxis, WindowYAxis, WindowWidth, WindowHeight
         WindowXAxis = areaaxis[0] + 12

--- a/green-recorder
+++ b/green-recorder
@@ -14,13 +14,20 @@
 
 # You should have received a copy of the GNU General Public License
 # along with Green Recorder.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+# Force GDK backend to be X11 because Wayland applications are not allowed to
+# know their window positions, which we need for selecting an area to record!
+os.environ['GDK_BACKEND'] = 'x11'
+
 import gi
 gi.require_version('AppIndicator3', '0.1')
 gi.require_version('Gtk','3.0')
 
 from gi.repository import Gtk, Gdk, GLib, AppIndicator3 as appindicator
 from pydbus import SessionBus
-import subprocess, signal, threading, datetime, gettext, locale, os, sys
+import subprocess, signal, threading, datetime, gettext, locale, sys
 
 try:
     # Python 3
@@ -468,13 +475,6 @@ if "wayland" in DisplayServer:
   
   formatchooser.append("webm", "WebM (The Open WebM Format)")
   formatchooser.set_active(0)
-
-  try:
-    s = os.getenv('GDK_BACKEND', '')
-    if "x11" not in s:
-      sendnotification(_("You didn't run the program using the application icon (desktop file). This will cause the program not to work. Run it using the icon from the menus only. (Need to export GDK_BACKEND=x11 first)"), 6)
-  except Exception as e:
-    print(e)
 
 class Handler:
     def recordclicked(self, GtkButton):

--- a/green-recorder
+++ b/green-recorder
@@ -20,7 +20,7 @@ gi.require_version('Gtk','3.0')
 
 from gi.repository import Gtk, Gdk, GLib, AppIndicator3 as appindicator
 from pydbus import SessionBus
-import subprocess, signal, threading, datetime, urllib, gettext, locale, os, ConfigParser
+import subprocess, signal, threading, datetime, urllib, gettext, locale, os, ConfigParser, sys
 
 # Configuration
 confDir =  os.path.join(GLib.get_user_config_dir(), 'green-recorder/')
@@ -331,10 +331,18 @@ def showabout(self):
     
 # Import the glade file and its widgets.
 builder = Gtk.Builder()
-try:
-  builder.add_from_file("/usr/share/green-recorder/ui.glade")
-except:
-  builder.add_from_file("/usr/local/share/green-recorder/ui.glade")
+possible_ui_file_locations = [
+    "/usr/share/green-recorder/ui.glade",
+    "/usr/local/share/green-recorder/ui.glade",
+    os.path.join(os.path.dirname(__file__), "ui", "ui.glade"),
+]
+for filename in possible_ui_file_locations:
+    if os.path.exists(filename):
+        builder.add_from_file(filename)
+        break
+else:
+    sys.exit("Did not find ui.glade.  Tried\n  %s"
+             % "\n  ".join(possible_ui_file_locations))
 
 # Create pointers.
 window = builder.get_object("window1")


### PR DESCRIPTION
This way you can run it under Wayland from the source tree without having to use the desktop file.

This commit belongs with #135, but it gets a bit hairy to untangle it from the Python 3 porting changes.  I can do that if you prefer.

This branch is based on top of #136, for historical reasons.